### PR TITLE
Actualizados los botones eliminar de modulo y sprint

### DIFF
--- a/ControldeCambios/Views/Modulos/Detalles.cshtml
+++ b/ControldeCambios/Views/Modulos/Detalles.cshtml
@@ -22,7 +22,12 @@
 @if (Model.requerimientos.Count == 0)
 {
     <button type="button" class="btn btn-danger" data-toggle="modal" data-target="#confirmModal">Eliminar</button>
-
+}
+else
+{
+    <a href="#" data-toggle="tooltip" title="No se puede eliminar este modulo porque tiene requerimientos asociados" data-placement="right">
+        <button type="button" class="btn btn-danger" data-toggle="modal" data-target="#confirmModal" disabled="disabled">Eliminar</button>
+    </a>
 }
 
 @using (Html.BeginForm("Detalles", "Modulos", FormMethod.Post, new { @class = "form-horizontal editFields", role = "form" }))
@@ -102,6 +107,9 @@
 <script>
         window.onload = function() {
             $('#list2').multiSelect();
+            $(document).ready(function () {
+                $('[data-toggle="tooltip"]').tooltip();
+            });
         };
 </script>
 

--- a/ControldeCambios/Views/Sprint/Detalles.cshtml
+++ b/ControldeCambios/Views/Sprint/Detalles.cshtml
@@ -23,6 +23,13 @@
 {
     <button type="button" class="btn btn-danger" data-toggle="modal" data-target="#confirmModal">Eliminar</button>
 }
+else
+{
+    <a href="#" data-toggle="tooltip" title="No se puede eliminar este sprint porque tiene modulos asociados" data-placement="right">
+        <button type="button" class="btn btn-danger" data-toggle="modal" data-target="#confirmModal" disabled="disabled">Eliminar</button>
+    </a>
+}
+
 @using (Html.BeginForm("Detalles", "Sprint", FormMethod.Post, new { @class = "form-horizontal editFields", role = "form" }))
 {
     @Html.AntiForgeryToken()
@@ -119,6 +126,9 @@
     <script>
             window.onload = function() {
                 $('#list2').multiSelect();
+                $(document).ready(function () {
+                    $('[data-toggle="tooltip"]').tooltip();
+                });
             };
     </script>
 


### PR DESCRIPTION
Los botones ya no se esconden al no cumplir los requerimientos para borrar modulo y sprint, ahora se oscurecen y muestran un mensaje explicando porque no se puede borrar.