### PR TITLE
Arreglado lo del acceso del lider al indice de solicitudes por aprobar

### DIFF
--- a/ControldeCambios/Controllers/ProyectosController.cs
+++ b/ControldeCambios/Controllers/ProyectosController.cs
@@ -368,6 +368,16 @@ namespace ControldeCambios.Controllers
             var model = new ProyectoInfoModel();
             model.proyecto = baseDatos.Proyectos.Find(id);
             model.proyectoLider = baseDatos.Usuarios.Find(model.proyecto.lider).nombre;
+            String userIdentityId = System.Web.HttpContext.Current.User.Identity.GetUserId();
+            String usuarioActual = baseDatos.Usuarios.Where(m => m.id == userIdentityId).First().cedula;
+            if (usuarioActual == model.proyecto.lider || System.Web.HttpContext.Current.User.IsInRole("Admin"))
+            {
+                ViewBag.permiso = true;
+            }
+            else
+            {
+                ViewBag.permiso = false;
+            }
             model.proyectoCliente = baseDatos.Usuarios.Find(model.proyecto.cliente).nombre;
             model.proyectoFechaInicio = model.proyecto.fechaInicio.ToString("dd/MM/yyyy");
             model.proyectoFechaFinal = model.proyecto.fechaFinal.ToString("dd/MM/yyyy");

--- a/ControldeCambios/Views/Proyectos/informacion.cshtml
+++ b/ControldeCambios/Views/Proyectos/informacion.cshtml
@@ -92,7 +92,7 @@
                 @Html.ActionLink("Mis solicitudes de cambios", "Index", "Solicitud_Cambios", new { proyecto = Model.proyecto.nombre }, new { @class = "btn btn-info" })
             </p>
         </div>
-        @if (System.Web.HttpContext.Current.User.IsInRole("Lider") || System.Web.HttpContext.Current.User.IsInRole("Admin"))
+        @if (ViewBag.permiso)
         {
         <div class="col-xs-12 col-sm-6">
             <p>


### PR DESCRIPTION
El acceso del lider estaba erroneo, el lider no es un rol sino un integrante del grupo especial, ahora la funcion se fija en ese campo antes de mostrar o no el boton que dirige a las solicitudes de cambios del equipo.